### PR TITLE
Add not-empty option to ms/string

### DIFF
--- a/src/more/spec/alpha.clj
+++ b/src/more/spec/alpha.clj
@@ -27,14 +27,16 @@
 
   Takes several kwargs options that further constrain the string:
 
+  :not-empty - the string is not empty (default false)
   :not-blank - the string is not blank (default false)
   :count - specifies the string length exactly (default nil)
   :min-count, :max-count - range of the string length (<= min-count count max-count)
                            (defaults nil)
   :match - the string matches a regexp, using clojure.core/re-matches
            (default nil)"
-  [& {:keys [not-blank count min-count max-count match]}]
+  [& {:keys [not-empty not-blank count min-count max-count match]}]
   (let [xs (cond-> []
+             not-empty (conj `not-empty)
              not-blank (conj `(complement clojure.string/blank?))
              count (conj `#(= ~count (c/count %)))
              min-count (conj `#(<= ~min-count (c/count %)))

--- a/test/more/spec/alpha_test.clj
+++ b/test/more/spec/alpha_test.clj
@@ -29,6 +29,8 @@
     (is (valid? (ms/string) "foo"))
     (is (valid? (ms/string) ""))
     (is (valid? (ms/string) " "))
+    (is (valid? (ms/string :not-empty true) "foo"))
+    (is (valid? (ms/string :not-empty true) " "))
     (is (valid? (ms/string :not-blank true) "foo"))
     (is (valid? (ms/string :count 3) "foo"))
     (is (valid? (ms/string :min-count 1 :max-count 4) "foo"))
@@ -37,6 +39,7 @@
   (testing "invalid"
     (is (false? (s/valid? (ms/string) 1)))
     (is (false? (s/valid? (ms/string) nil)))
+    (is (false? (s/valid? (ms/string :not-empty true) "")))
     (is (false? (s/valid? (ms/string :not-blank true) "")))
     (is (false? (s/valid? (ms/string :not-blank true) " ")))
     (is (false? (s/valid? (ms/string :count 3) "foobar")))


### PR DESCRIPTION
Add `:not-empty` option to `more.spec.alpha/string`.

```clojure
(ms/string :not-empty true)
```